### PR TITLE
Setting to turn-off default mapping

### DIFF
--- a/doc/blockle.txt
+++ b/doc/blockle.txt
@@ -35,18 +35,15 @@ MAPPINGS                                               *blockle-mappings*
 <Leader>b   or   <Plug>BlockToggle
   Toggle ruby block style
 
-To add your own mapping, add something like the following to your vim configuration:
+To override default mapping, add something like the following to your vim configuration:
+>
+  let g:blockle_mapping = '<Leader>bl'
+<
+To add additional mapping, add something like the following to your vim configuration:
 >
   map <D-j> <Plug>BlockToggle
 <
-which would map Super-J (Cmd-J on Mac OS) to the toggling function.
+which would additionally map Super-J (Cmd-J on Mac OS) to the toggling function.
 
-
-                                                       *blockle-settings*
-
-To skip default mapping (<Leader>b for ruby filetype) put following in .vimrc:
->
-  let g:blockle_skip_mappings = 1
-<
 
  vim:tw=78:et:ft=help:norl:

--- a/plugin/blockle.vim
+++ b/plugin/blockle.vim
@@ -137,12 +137,14 @@ endfunction
 
 nnoremap <silent> <Plug>BlockToggle :<C-U>call <SID>ToggleDoEndOrBrackets()<CR>
 
-if (!exists("g:blockle_skip_mappings") || !g:blockle_skip_mappings)
-  augroup blockle
-    autocmd!
-    autocmd FileType ruby map <buffer> <leader>b <Plug>BlockToggle
-  augroup END
+if !exists("g:blockle_mapping")
+  let g:blockle_mapping = '<Leader>b'
 endif
+
+augroup blockle
+  autocmd!
+  exec 'autocmd FileType ruby map <buffer> ' . g:blockle_mapping . ' <Plug>BlockToggle'
+augroup END
 
 let &cpo = s:cpo_save
 


### PR DESCRIPTION
Hey,

I've just noticed that vim-blockle's mapping was colliding with one of my mappings and there was no way to skip it. I've just added this settings, merge it if you like it.

```
let g:blockle_skip_mappings = 1
```

The other option is to allow user to do sth like this:

```
let g:blockle_mapping = '<D-j>'
```

But this can also be achieved by 'skipping' default mapping and doing 'map <D-j> <Plug>BlockToggle'.

What are your thoughts?
