### PR TITLE
temporary turn off delimitmate plugin when converting do/end to brackets

### DIFF
--- a/plugin/blockle.vim
+++ b/plugin/blockle.vim
@@ -84,9 +84,14 @@ function! s:ConvertDoEndToBrackets()
   norm %
   let lines = (line('.')-begin_num+1)
 
+
+  call s:TurnAutocloseOff()
+
   norm ciw}
   call setpos('.', do_pos)
   norm ciw{
+
+  call s:TurnAutocloseOn()
 
   if lines == 3
     norm! JJ
@@ -137,6 +142,18 @@ function! s:ToggleDoEndOrBrackets()
   let &paste = paste_mode
 
   silent! call repeat#set("\<Plug>BlockToggle", -1)
+endfunction
+
+function! s:TurnAutocloseOff()
+  if exists("b:delimitMate_enabled") && b:delimitMate_enabled
+    silent! DelimitMateSwitch
+  endif
+endfunction
+
+function! s:TurnAutocloseOn()
+  if exists("b:delimitMate_enabled") && !b:delimitMate_enabled
+    silent! DelimitMateSwitch
+  endif
 endfunction
 
 nnoremap <silent> <Plug>BlockToggle :<C-U>call <SID>ToggleDoEndOrBrackets()<CR>


### PR DESCRIPTION
Hi Joshua,

I've found that delimitMate adds an extra } when you are trying to convert the do/end to the brackets.
I've added a small patch temporary turn it off/on.

An example of issue:

should do 
  validate_presence_of :name
end

becomes

should {} validate_presence_of :name }

Thanks,
Alex
