### PR TITLE
fix autoparing brackets, when use blockle with autoparing plugins

### DIFF
--- a/plugin/blockle.vim
+++ b/plugin/blockle.vim
@@ -86,13 +86,13 @@ function! s:ConvertDoEndToBrackets()
 
   norm ciw}
   call setpos('.', do_pos)
-  norm dw
+  norm de
   
   let line = getline(begin_num)
-  let before_do_str = strpart(line, 0, do_pos[2])
-  let after_do_str  = strpart(line, do_pos[2] + 1)
+  let before_do_str = strpart(line, 0, do_pos[2] - 1)
+  let after_do_str  = strpart(line, do_pos[2])
 
-  call setline(begin_num, before_do_str . "{" . after_do_str)
+  call setline(begin_num, before_do_str . "{ " . after_do_str)
 
   if lines == 3
     norm! JJ


### PR DESCRIPTION
Hi Joshua,

here is another try to fix the issue with autoparing plugins, when you have them installed along with blockle plugin. I've tested it with delimitmate. 

Thanks,
Alex
